### PR TITLE
feat(agents): add gold-patch oracle agent

### DIFF
--- a/docker_agent/agents.toml
+++ b/docker_agent/agents.toml
@@ -10,6 +10,10 @@ branch = "main"
 install_command = "uv sync --all-extras"
 
 [[agents]]
+name = "oracle"
+model = "oracle"
+
+[[agents]]
 name = "agentless"
 model = "deepseek-chat"
 provider = "deepseek"

--- a/docker_agent/agents/base.py
+++ b/docker_agent/agents/base.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import Dict, Any, Optional, List
 
-from docker_agent.core.types import Container, Spec
+from docker_agent.core.types import Container
 from docker_agent.parsing.patch_analyzer import PatchAnalyzer
 from docker_agent.utils.command_executor import DockerCommandExecutor
 from docker_agent.core.exceptions import AgentSetupError
@@ -56,19 +56,13 @@ class BaseAgent:
         pass
 
     @abstractmethod
-    def evaluate(self, spec: Spec, operator, *args, **kwargs) -> Dict[str, Any]:
-        """
-        Evaluate agent on a specific spec - must be implemented by subclass (clone or copy)
+    def run(self, problem_statement: str, instance_id: str, repo_name: str) -> tuple[bool, str]:
+        """Run agent to solve problem - must be implemented by subclass"""
+        pass
 
-        Args:
-            spec: Evaluation specification
-            operator: ContainerOperator instance
-            *args: Additional positional arguments
-            **kwargs: Additional keyword arguments
-
-        Returns:
-            Evaluation result dictionary
-        """
+    @abstractmethod
+    def parse_agent_log(self, log: str) -> Dict[str, Optional[int]]:
+        """Parse agent log to extract token usage - must be implemented by subclass"""
         pass
 
     @abstractmethod

--- a/docker_agent/agents/manager.py
+++ b/docker_agent/agents/manager.py
@@ -36,7 +36,97 @@ class AgentManager:
 
     def evaluate(self, spec, operator, *args, **kwargs) -> Dict[str, Any]:
         """Evaluate agent on spec"""
-        return self.agent.evaluate(spec, operator, *args, **kwargs)
+        from docker_agent.parsing.pytest_parser import TestStatus
+
+        try:
+            self.agent.setup()
+
+            operator.checkout_commit(spec.base_commit, use_docker=True)
+            agent_success, agent_output = self.agent.run(
+                spec.problem_statement,
+                spec.instance_id,
+                spec.repo_name,
+            )
+
+            if agent_success:
+                f2p_tests: List[str] = []
+                p2p_tests: List[str] = []
+                if spec.FAIL_TO_PASS:
+                    f2p_tests.extend(spec.FAIL_TO_PASS.split(", "))
+                if spec.PASS_TO_PASS:
+                    p2p_tests.extend(spec.PASS_TO_PASS.split(", "))
+
+                # ---- FAIL_TO_PASS ----------------------------------------
+                operator.checkout_commit(spec.base_commit, exclude_file=["patch.diff"], use_docker=True)
+                self.agent.path_analyzer.apply_patch_file_to_container(
+                    self.agent.base_path / "swap" / spec.repo_name / "patch.diff",
+                    self.agent.docker_executor,
+                    "/workdir/swap/" + spec.repo_name,
+                    include_test=False,
+                )
+                if spec.test_patch:
+                    operator.apply_patches(spec.test_patch)
+
+                f2p_passed: set = set()
+                if f2p_tests:
+                    f2p_passed, _ = operator.run_tests_in_container(
+                        spec.repo_name, f2p_tests, [TestStatus.PASSED], False
+                    )
+
+                # ---- PASS_TO_PASS ----------------------------------------
+                operator.checkout_commit(spec.base_commit, exclude_file=["patch.diff"], use_docker=True)
+                self.agent.path_analyzer.apply_patch_file_to_container(
+                    self.agent.base_path / "swap" / spec.repo_name / "patch.diff",
+                    self.agent.docker_executor,
+                    "/workdir/swap/" + spec.repo_name,
+                    include_test=False,
+                )
+                if spec.test_patch:
+                    operator.apply_patches(spec.test_patch)
+
+                p2p_passed: set = set()
+                if p2p_tests:
+                    p2p_passed, _ = operator.run_tests_in_container(
+                        spec.repo_name, p2p_tests, [TestStatus.PASSED]
+                    )
+
+                success_f2p = all(test in f2p_passed for test in f2p_tests)
+                success_p2p = all(test in p2p_passed for test in p2p_tests)
+                success = success_f2p and success_p2p
+
+                total_tokens = self.agent.parse_agent_log(agent_output)
+
+                return {
+                    "agent": self.agent.agent_config.name,
+                    "model": self.agent.agent_config.model,
+                    "instance_id": spec.instance_id,
+                    "success_f2p": success_f2p,
+                    "success_p2p": success_p2p,
+                    "success": success,
+                    "passed_f2p_tests": list(f2p_passed),
+                    "passed_p2p_tests": list(p2p_passed),
+                    "expected_f2p_tests": f2p_tests,
+                    "expected_p2p_tests": p2p_tests,
+                    "total_tokens": total_tokens,
+                }
+            else:
+                return {
+                    "agent": self.agent.agent_config.name,
+                    "model": self.agent.agent_config.model,
+                    "instance_id": spec.instance_id,
+                    "success": False,
+                    "error": agent_output,
+                }
+
+        except Exception as e:
+            self.logger.error(f"Error evaluating {self.agent.agent_config.name} on {spec.instance_id}: {e}")
+            return {
+                "agent": self.agent.agent_config.name,
+                "model": self.agent.agent_config.model,
+                "instance_id": spec.instance_id,
+                "success": False,
+                "error": str(e),
+            }
 
     def prepare_resources(self) -> Optional[List[Dict[str, Any]]]:
         """

--- a/docker_agent/agents/manager.py
+++ b/docker_agent/agents/manager.py
@@ -6,7 +6,8 @@ from typing import Dict, Any, Optional, List
 
 from docker_agent.agents.base import BaseAgent
 from docker_agent.agents.trae_agent import TraeAgent
-from docker_agent.agents.agentless import Agentless
+from docker_agent.agents.oracle_agent import OracleAgent
+# from docker_agent.agents.agentless import Agentless
 from docker_agent.core.exceptions import ConfigurationError
 
 
@@ -25,8 +26,10 @@ class AgentManager:
 
         if agent_name == "trae-agent":
             return TraeAgent(self.container, self.agent_config)
+        elif agent_name == "oracle":
+            return OracleAgent(self.container, self.agent_config)
         elif agent_name == "agentless":
-            return Agentless(self.container, self.agent_config)
+            raise NotImplementedError("Agentless evaluation is not included")
         else:
             raise ConfigurationError(f"Unsupported agent type: {self.agent_config.name}")
 
@@ -42,6 +45,9 @@ class AgentManager:
             self.agent.setup()
 
             operator.checkout_commit(spec.base_commit, use_docker=True)
+            if isinstance(self.agent, OracleAgent):
+                self.agent.spec_patch = spec.patch
+
             agent_success, agent_output = self.agent.run(
                 spec.problem_statement,
                 spec.instance_id,

--- a/docker_agent/agents/oracle_agent.py
+++ b/docker_agent/agents/oracle_agent.py
@@ -1,0 +1,98 @@
+"""Oracle Agent - applies the ground-truth patch from the dataset"""
+
+from pathlib import Path
+from typing import Dict, Any, Optional, List
+
+from docker_agent.agents.base import BaseAgent
+from docker_agent.parsing.patch_analyzer import PatchInfo
+
+
+class OracleAgent(BaseAgent):
+    """
+    Oracle agent that applies the ground-truth patch directly from the dataset.
+
+    This agent does not run any LLM; instead it applies ``spec.patch``
+    (a list of GitHub-style file-change dicts) to the repository and then
+    captures the result with ``git diff``, exactly like the other agents
+    produce their ``patch.diff`` artefact.  It serves as an upper-bound
+    reference when evaluating the benchmark.
+
+    Usage in manager.py:
+        ``AgentManager.evaluate()`` sets ``agent.spec_patch = spec.patch``
+        before calling ``agent.run()``.
+    """
+
+    def __init__(self, container, agent_config):
+        super().__init__(container, agent_config)
+        # Set by AgentManager.evaluate() before run() is called.
+        self.spec_patch: Optional[List[Dict]] = None
+
+    # ------------------------------------------------------------------
+    # BaseAgent interface
+    # ------------------------------------------------------------------
+
+    def _prepare_agent_code(self):
+        """No external agent code to install."""
+        self.logger.info("OracleAgent: no agent code to prepare")
+
+    def run(self, problem_statement: str, instance_id: str, repo_name: str) -> tuple[bool, str]:
+        """Apply the ground-truth patch and capture a git diff as patch.diff."""
+        self.logger.info(f"OracleAgent: applying ground-truth patch for {instance_id}")
+
+        if not self.spec_patch:
+            msg = "OracleAgent.run() called without spec_patch being set"
+            self.logger.error(msg)
+            return False, msg
+
+        repo_workdir = f"/workdir/swap/{repo_name}"
+        patch_path = f"{repo_workdir}/patch.diff"
+
+        try:
+            # Build PatchInfo objects from the GitHub-style diff dicts.
+            patches: List[PatchInfo] = []
+            for change in self.spec_patch:
+                filename = change.get("filename")
+                patch_content = change.get("patch", "")
+                status = change.get("status", "")
+
+                if not filename or not patch_content or not status:
+                    continue
+
+                patches.append(PatchInfo(
+                    filename=filename,
+                    status=status,
+                    patch_content=patch_content,
+                    is_test_file=self.path_analyzer.is_test_file(filename),
+                ))
+
+            if not patches:
+                msg = "OracleAgent: no valid patches found in spec_patch"
+                self.logger.warning(msg)
+                return False, msg
+
+            applied = self.path_analyzer.apply_patches_to_container(
+                patches, self.docker_executor, repo_workdir
+            )
+            self.logger.info(f"OracleAgent: applied patches to {len(applied)} file(s): {applied}")
+
+            # Produce the patch.diff artefact that the evaluator expects.
+            diff_exit, diff_output = self.docker_executor.execute(
+                f"git diff > {patch_path}", repo_workdir, stream=True
+            )
+            if diff_exit != 0:
+                self.logger.warning(f"OracleAgent: git diff failed: {diff_output}")
+                return False, diff_output
+
+            return True, f"Applied {len(applied)} patch(es): {applied}"
+
+        except Exception as e:
+            self.logger.error(f"OracleAgent error: {e}")
+            return False, str(e)
+
+    def parse_agent_log(self, log: str) -> Dict[str, Optional[int]]:
+        """Oracle generates no LLM tokens."""
+        return {"Total Tokens": None, "Input Tokens": None, "Output Tokens": None}
+
+    def prepare_resources(self) -> Optional[List[Dict[str, Any]]]:
+        """No pre-computed resources needed."""
+        return None

--- a/docker_agent/agents/trae_agent.py
+++ b/docker_agent/agents/trae_agent.py
@@ -5,8 +5,6 @@ import re
 from typing import Dict, Any, Optional, List
 
 from docker_agent.agents.base import BaseAgent
-from docker_agent.core.types import Spec
-from docker_agent.container.container_operator import ContainerOperator
 from docker_agent.core.exceptions import AgentSetupError
 
 
@@ -51,102 +49,6 @@ class TraeAgent(BaseAgent):
             f"--model {self.agent_config.model} "
             f"--provider {self.agent_config.provider} "
             f"--config-file /workdir/swap/trae-agent/trae_config.yaml")
-
-    def evaluate(self, spec: Spec, operator: ContainerOperator) -> Dict[str, Any]:
-        """
-        Evaluate TraeAgent on a specific spec
-
-        This method contains TraeAgent-specific evaluation logic:
-        - Setup agent environment
-        - Run agent on problem
-        - Extract tokens from output
-        """
-        from docker_agent.parsing.pytest_parser import TestStatus
-
-        try:
-            self.setup()
-
-            operator.checkout_commit(spec.base_commit, use_docker=True)
-            agent_success, agent_output = self.run(
-                spec.problem_statement,
-                spec.instance_id,
-                spec.repo_name
-            )
-
-            if agent_success:
-                operator.checkout_commit(spec.base_commit, exclude_file=["patch.diff"], use_docker=True)
-
-                self.path_analyzer.apply_patch_file_to_container(
-                    self.base_path / "swap" / spec.repo_name / "patch.diff", self.docker_executor, "/workdir/swap/" + spec.repo_name, include_test=False
-                )
-
-                if spec.test_patch:
-                    operator.apply_patches(spec.test_patch)
-
-                f2p_tests, p2p_tests = [], []
-                if spec.FAIL_TO_PASS:
-                    f2p_tests.extend(spec.FAIL_TO_PASS.split(", "))
-                if spec.PASS_TO_PASS:
-                    p2p_tests.extend(spec.PASS_TO_PASS.split(", "))
-
-                f2p_passed, _ = set(), set()
-                if f2p_tests:
-                    f2p_passed, _ = operator.run_tests_in_container(
-                        spec.repo_name, f2p_tests, [TestStatus.PASSED], False
-                    )
-
-                operator.checkout_commit(spec.base_commit, exclude_file=["patch.diff"], use_docker=True)
-
-                self.path_analyzer.apply_patch_file_to_container(
-                    self.base_path / "swap" / spec.repo_name / "patch.diff", self.docker_executor, "/workdir/swap/" + spec.repo_name, include_test=False
-                )
-
-                if spec.test_patch:
-                    operator.apply_patches(spec.test_patch)
-
-                p2p_passed, _ = set(), set()
-                if p2p_tests:
-                    p2p_passed, _ = operator.run_tests_in_container(
-                        spec.repo_name, p2p_tests, [TestStatus.PASSED]
-                    )
-
-                success_f2p = all(test in f2p_passed for test in f2p_tests)
-                success_p2p = all(test in p2p_passed for test in p2p_tests)
-                success = success_f2p and success_p2p
-
-                total_tokens = self.parse_agent_log(agent_output)
-
-                return {
-                    "agent": self.agent_config.name,
-                    "model": self.agent_config.model,
-                    "instance_id": spec.instance_id,
-                    "success_f2p": success_f2p,
-                    "success_p2p": success_p2p,
-                    "success": success,
-                    "passed_f2p_tests": list(f2p_passed),
-                    "passed_p2p_tests": list(p2p_passed),
-                    "expected_f2p_tests": f2p_tests,
-                    "expected_p2p_tests": p2p_tests,
-                    "total_tokens": total_tokens,
-                }
-            else:
-                return {
-                    "agent": self.agent_config.name,
-                    "model": self.agent_config.model,
-                    "instance_id": spec.instance_id,
-                    "success": False,
-                    "error": agent_output,
-                }
-
-        except Exception as e:
-            self.logger.error(f"Error evaluating {self.agent_config.name} on {spec.instance_id}: {e}")
-            return {
-                "agent": self.agent_config.name,
-                "model": self.agent_config.model,
-                "instance_id": spec.instance_id,
-                "success": False,
-                "error": str(e),
-            }
 
     @staticmethod
     def clean_ansi_codes(text: str) -> str:


### PR DESCRIPTION
## Summary
This PR adds an **Oracle baseline agent** and refactors evaluation so all agents use a shared evaluation loop in `AgentManager`.

This supports investigation of the low gold-patch resolve rate reported in **Issue #7**.

## What changed
- Added `OracleAgent`:
  - Applies `spec.patch` (ground-truth dataset patch) directly to the checked-out repo.
- Registered a new agent config:
  - `name = "oracle"`, `model = "oracle"`.
- Refactored evaluation flow:
  - Moved core eval loop (checkout, patch application, F2P/P2P test execution, result assembly) from agent-specific implementation into `AgentManager.evaluate()`.
  - Standardized agent interface around `run(...)` and `parse_agent_log(...)`.

## Why
- Creates a clean baseline to separate:
  - dataset patch correctness from
  - runtime/container/environment issues during P2P.
- Reduces duplicated evaluation logic and keeps scoring behavior consistent across agents.
